### PR TITLE
在 html.h 中增加 _rndr_inter_listitem api 让 MWeb 调用

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -291,7 +291,7 @@ is_end_of_br_or_tag(uint8_t* s, size_t size) {
 }
 
 
-static void
+void
 _rndr_inter_listitem(hoedown_buffer *ob, const hoedown_buffer *content, size_t offset,  hoedown_list_flags flags, const hoedown_renderer_data *data)
 {
     hoedown_html_renderer_state *state = data->opaque;

--- a/src/html.h
+++ b/src/html.h
@@ -75,7 +75,8 @@ hoedown_renderer *hoedown_html_toc_renderer_new(
 
 /* hoedown_html_renderer_free: deallocate an HTML renderer */
 void hoedown_html_renderer_free(hoedown_renderer *renderer);
-
+/* add api for mweb */
+void _rndr_inter_listitem(hoedown_buffer *ob, const hoedown_buffer *content, size_t offset,  hoedown_list_flags flags, const hoedown_renderer_data *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
在 html.h 中增加 _rndr_inter_listitem api 让 MWeb 调用， html.c 中去掉 static 声明。